### PR TITLE
Refactor/monorepo/eslint-typecheck

### DIFF
--- a/configs/eslint.config.typed.js
+++ b/configs/eslint.config.typed.js
@@ -1,5 +1,5 @@
-// src: configs/eslint.config.js
-// @(#) : ESLint flat config for TypeScript workspace
+// src: /configs/eslint.config.typed.js
+// @(#) : eslint float config for type check
 //
 // Copyright (c) 2025 atsushifx <http://github.com/atsushifx>
 //
@@ -11,42 +11,53 @@ import path from 'path';
 import { dirname } from 'path';
 import { fileURLToPath } from 'url';
 
+// plugins
+import tseslint from '@typescript-eslint/eslint-plugin';
 // parser
 import tsparser from '@typescript-eslint/parser';
 
 // import form common base config
-import baseConfig from '../shared/configs/eslint.config.base.js';
 import projectPaths from '../shared/configs/eslint.projects.js';
+import typedRules from '../shared/configs/eslint.rules.typed.js';
 
-// set __dirname for ESM
+// directories
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const rootDir = path.resolve(__dirname, '../');
+const rootDir = path.resolve(__dirname, '..');
 
-// settings
+// eslint configs
 export default [
-  ...baseConfig,
-
-  // source code settings
   {
     files: [
-      'shared/common/**/*.ts',
-      'packages/**/src/**/*.ts',
+      'shared/**/*.ts',
+      'packages/**/*.ts',
     ],
+    ignores: [
+      '*lib/**',
+      '**/module/**',
+      '**/dist/**',
+      '**/node_modules/**',
+      '**/.cache/**',
+      '**/configs/**',
+    ],
+    plugins: {
+      '@typescript-eslint': tseslint,
+    },
     languageOptions: {
       parser: tsparser,
       parserOptions: {
-        tsconfigRootDir: rootDir,
         project: projectPaths,
+        tsconfigRootDir: rootDir,
+        sourceType: 'module',
       },
     },
     settings: {
       'import/resolver': {
         typescript: {
-          tsconfigRootDir: rootDir,
           project: projectPaths,
-          noWarnOnMultipleProjects: true,
+          tsconfigRootDir: rootDir,
         },
       },
     },
+    rules: typedRules,
   },
 ];

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -25,13 +25,13 @@ pre-commit:
       glob:
         - "shared/**/*.ts"
         - "packages/**/*.ts"
-      run: pnpm run lint
+      run: pnpm run lint-all -- "{staged_files}"
 
     eslint-types:
       glob:
         - "shared/**/*.ts"
         - "packages/**/*.ts"
-      run: pnpm run lint:types
+      run: pnpm run lint-all-types -- "{staged_files}"
 
     lint-spells:
       glob:

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "lint:types": "pnpm -r run lint:types",
     "lint:fix": "echo 'skip where project root'",
     "lint-all": "pnpm exec eslint --config ./configs/eslint.config.js --cache --cache-location .cache/eslint-cache/esLintCache",
+    "lint-all-types": "pnpm exec eslint --config ./configs/eslint.config.typed.js ",
     "lint:secrets": "secretlint --secretlintrc ./configs/secretlint.config.yaml --secretlintignore .gitignore --maskSecrets **/*"
   }
 }

--- a/shared/configs/eslint.config.base.js
+++ b/shared/configs/eslint.config.base.js
@@ -107,26 +107,4 @@ export default [
       },
     },
   },
-
-  // --- 3. for config files overwritten rules
-  {
-    files: [
-      '*.config*.ts',
-      '*.config*.js',
-    ],
-    languageOptions: {
-      parser: tsparser,
-      parserOptions: {
-        project: false, // 型チェックを無効化
-        sourceType: 'module',
-        ecmaVersion: 'latest',
-      },
-    },
-    plugins: {
-      'import': importPlugin,
-    },
-    rules: {
-      'import/order': 'warn', // 必要なら他の差分ルールもここで
-    },
-  },
 ];

--- a/shared/configs/eslint.config.typed.base.js
+++ b/shared/configs/eslint.config.typed.base.js
@@ -6,38 +6,44 @@
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 
-// --- plugins
+// -- import
+// rules
+import js from '@eslint/js';
+// plugins
 import tseslint from '@typescript-eslint/eslint-plugin';
+// parser
+import tsparser from '@typescript-eslint/parser';
+// importer
+import importPlugin from 'eslint-plugin-import';
 
-// --- base configs
-import baseConfig from './eslint.config.base.js';
+// -- rules
+import typedRules from './eslint.rules.typed.js';
 
 /** @type {import('eslint').Linter.FlatConfig[]} */
 export default [
-  // --- 共通のbaseConfigを先頭に展開
-  ...baseConfig,
-
-  // --- rules for TypeScript type check (override)
   {
     files: [
-      'src/**/*.ts',
-      'tests/**/*.ts',
-      'types/**/*.ts',
+      '**/*.ts',
     ],
+    ignores: [
+      '**/lib/**',
+      '**/module/**',
+      '**/dist/**',
+      '**/node_modules/**',
+      '**/.cache/**',
+      '**/configs/**',
+      '**/scripts/**',
+    ],
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: '.',
+        sourceType: 'module',
+      },
+    },
     plugins: {
       '@typescript-eslint': tseslint,
     },
-    rules: {
-      // type check rules
-      '@typescript-eslint/prefer-nullish-coalescing': 'warn',
-      '@typescript-eslint/prefer-optional-chain': 'warn',
-      '@typescript-eslint/explicit-function-return-type': ['warn', {
-        allowExpressions: true,
-        allowConciseArrowFunctionExpressionsStartingWithVoid: true,
-      }],
-      '@typescript-eslint/no-unnecessary-type-assertion': 'warn',
-      '@typescript-eslint/no-unnecessary-condition': 'warn',
-      '@typescript-eslint/restrict-template-expressions': 'warn',
-    },
+    rules: typedRules,
   },
 ];

--- a/shared/configs/eslint.rules.typed.js
+++ b/shared/configs/eslint.rules.typed.js
@@ -1,0 +1,22 @@
+// src: /shared/configs/eslint.rules.typed.js
+// @(#) : ESLint rules for type check
+//
+// Copyright (c) 2025 atsushifx <http://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// rules
+/** @type {import('eslint').Linter.FlatConfig[]} */
+export default {
+  // type check rules
+  '@typescript-eslint/prefer-nullish-coalescing': 'warn',
+  '@typescript-eslint/prefer-optional-chain': 'warn',
+  '@typescript-eslint/explicit-function-return-type': ['warn', {
+    allowExpressions: true,
+    allowConciseArrowFunctionExpressionsStartingWithVoid: true,
+  }],
+  '@typescript-eslint/no-unnecessary-type-assertion': 'warn',
+  '@typescript-eslint/no-unnecessary-condition': 'warn',
+  '@typescript-eslint/restrict-template-expressions': 'warn',
+};


### PR DESCRIPTION
## ✨ Overview

Enables type-aware ESLint linting from the monorepo root, using shared configurations.
This allows consistent type checking across all sub-packages via a centralized `eslint.config.typed.js` setup, and integrates the check into `lefthook` pre-commit hooks.

---

## 🔧 Changes

- [ ] Added/updated files or modules
- [ ] Removed deprecated logic or configs
- [ ] Refactored[X]for clarity/performance
- [ ] Other (please describe below)

---

## 📂 Related Issues

> Closes #25

---

## ✅ Checklist

Please confirm the following before requesting review:

- [ ] Lint checks pass (`pnpm lint`)
- [ ] Tests pass (`pnpm test`)
- [ ] Documentation is updated (if applicable)
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Descriptions and examples are clear

---

## 💬 Additional Notes

- The typed lint rules are defined in `eslint.config.typed.base.js` and applied to `.ts` files only
- `configs/**/*` is explicitly excluded from lint scope to avoid parser errors
- Shared tsconfig paths are centralized in `eslint.projects.js`

